### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/example/vulnerable_code/templates/attackerSite.html
+++ b/example/vulnerable_code/templates/attackerSite.html
@@ -4,7 +4,7 @@
   <body onload="exploit()"> hest
 
     <form name="myForm" action="127.0.0.1:5000/example2action" method=post>
-      <input type=text size=30 name=title value=<script> var u = 'http://'>
+      <input type=text size=30 name=title value=<script/> var u = 'http://'>
       <input type=submit name=submitBtn  />
     </form>
   </body>

--- a/example/vulnerable_code/templates/example2_form.html
+++ b/example/vulnerable_code/templates/example2_form.html
@@ -2,7 +2,7 @@
 <body> hest </body>
 
 <form action="{{ url_for('example2_action') }}" method=post>
-  <input type=text size=30 name=title>
+  <input type=text size=30 name=title/>
   <input type=submit name=submitBtn  />
 </form>
 </html>

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/plugins/portal/templates/index.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/plugins/portal/templates/index.html
@@ -98,7 +98,7 @@
         <div class="portal-content">
             {{ topic.first_post.content | markup | safe }}<br />
         </div>
-        {% if not loop.last %}<hr>{% endif %}
+        {% if not loop.last %}<hr/>{% endif %}
       {% endfor %}
 
       </div> <!-- /.panel-body -->

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/auth/reset_password.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/auth/reset_password.html
@@ -6,7 +6,7 @@
 
 <form class="form-horizontal" role="form" method="POST">
     <h2>{% trans %}Reset Password{% endtrans %}</h2>
-    <hr>
+    <hr/>
         {{ form.hidden_tag() }}
         {{ form.token }}
         {{ horizontal_field(form.email) }}

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/editor_help.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/editor_help.html
@@ -16,16 +16,16 @@
                     <h2>Typography</h2>
                     <div class="typography">
                         <span >
-                            # Header1 <br>
-                            ## Header2 <br>
+                            # Header1 <br/>
+                            ## Header2 <br/>
                         </span>
                         <span>
-                            * Unordered item1 <br>
-                            * Unordered item2 <br>
+                            * Unordered item1 <br/>
+                            * Unordered item2 <br/>
                         </span>
                         <span>
-                            1. Ordered item1 <br>
-                            2. Ordered item2 <br>
+                            1. Ordered item1 <br/>
+                            2. Ordered item2 <br/>
                         </span>
                     </div>
                     <p class="text-center" style="margin-top: 1em;">*<em>Emphasized text</em>*</p>
@@ -42,8 +42,8 @@
                     <div class="code-hints" style="margin-top: 2em;">
                         <div class="code-example">
                             <span>
-                            ```python <br>
-                            print "Hello world"<br>
+                            ```python <br/>
+                            print "Hello world"<br/>
                             ```
                             </span>
 

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/forum/edit_forum.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/forum/edit_forum.html
@@ -6,7 +6,7 @@
 {% from theme('macros.html') import render_pagination, topic_pages %}
 
 <form class="form" role="form" method="POST">
-    <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
+    <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"/></div>
 
     <div class="forum-view">
         <ol class="breadcrumb flaskbb-breadcrumb">

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/forum/search_result.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/forum/search_result.html
@@ -33,7 +33,7 @@
                     <div class="author-title"><h5>{{ post.user.primary_group.name }}</h5></div>
 
                     {% if post.user.avatar %}
-                        <div class="author-avatar"><img src="{{ post.user.avatar }}" alt="avatar"></div>
+                        <div class="author-avatar"><img src="{{ post.user.avatar }}" alt="avatar"/></div>
                     {% endif %}
 
                     <div class="author-registered">{% trans %}Joined{% endtrans %}: {{ post.user.date_joined|format_date('%b %d %Y') }}</div>

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/forum/topic.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/forum/topic.html
@@ -37,7 +37,7 @@
                     <div class="author-title"><h5>{{ user.primary_group.name }}</h5></div>
 
                     {% if user.avatar %}
-                        <div class="author-avatar"><img src="{{ user.avatar }}" alt="avatar"></div>
+                        <div class="author-avatar"><img src="{{ user.avatar }}" alt="avatar"/></div>
                     {% endif %}
 
                     <div class="author-registered">{% trans %}Joined{% endtrans %}: {{ user.date_joined|format_date('%b %d %Y') }}</div>

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/forum/topic_horizontal.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/forum/topic_horizontal.html
@@ -3,7 +3,7 @@
 {% set active_forum_nav=True %}
 
 {% block css %}
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-markdown.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-markdown.min.css') }}"/>
 {% endblock %}
 
 {% block content %}
@@ -31,7 +31,7 @@
                     <div class="pull-left">
                         {% if user.avatar %}
                         <div class="author-box">
-                            <div class="author-avatar hidden-xs"><img src="{{ user.avatar }}" alt="avatar"></div>
+                            <div class="author-avatar hidden-xs"><img src="{{ user.avatar }}" alt="avatar"/></div>
                         </div>
                         {% endif %}
 

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/forum/topictracker.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/forum/topictracker.html
@@ -6,7 +6,7 @@
 {% from theme('macros.html') import render_pagination, topic_pages %}
 
 <form class="form" role="form" method="POST">
-    <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
+    <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"/></div>
 
     <div class="forum-view">
 

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/layout.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/layout.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="FlaskBB is a forum software written in Flask">
-        <meta name="author" content="FlaskBB Team">
-        <meta name="csrf-token" content="{{ csrf_token() }}">
-        <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
+        <meta charset="utf-8"/>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <meta name="description" content="FlaskBB is a forum software written in Flask"/>
+        <meta name="author" content="FlaskBB Team"/>
+        <meta name="csrf-token" content="{{ csrf_token() }}"/>
+        <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}"/>
 
         <title>
         {% block title %}
@@ -21,9 +21,9 @@
 
         {% block stylesheets %}
         <!-- syntax highlighting -->
-        <link rel="stylesheet" href="{{ url_for('static', filename='css/pygments.css') }}">
+        <link rel="stylesheet" href="{{ url_for('static', filename='css/pygments.css') }}"/>
         <!-- bootstrap & aurora theme -->
-        <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+        <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}"/>
         {% endblock %}
 
         {# for extra stylesheets. e.q. a template has to add something #}

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/message/conversation.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/message/conversation.html
@@ -1,7 +1,7 @@
 {% extends theme("message/message_layout.html") %}
 
 {% block css %}
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-markdown.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-markdown.min.css') }}"/>
 {% endblock %}
 
 {% block message_content %}
@@ -37,7 +37,7 @@
                         <div class="author-title"><h5>{{ message.user.primary_group.name }}</h5></div>
 
                         {% if message.user.avatar %}
-                            <div class="author-avatar"><img src="{{ message.user.avatar }}" alt="avatar"></div>
+                            <div class="author-avatar"><img src="{{ message.user.avatar }}" alt="avatar"/></div>
                         {% endif %}
 
                         <div class="author-registered">{% trans %}Joined{% endtrans %}: {{ message.user.date_joined|format_date('%b %d %Y') }}</div>
@@ -88,7 +88,7 @@
                         <div class="author-title"><h5>{{ message.user.primary_group.name }}</h5></div>
 
                         {% if message.user.avatar %}
-                            <div class="author-avatar"><img src="{{ message.user.avatar }}" alt="avatar"></div>
+                            <div class="author-avatar"><img src="{{ message.user.avatar }}" alt="avatar"/></div>
                         {% endif %}
 
                         <div class="author-registered">{% trans %}Joined{% endtrans %}: {{ message.user.date_joined|format_date('%b %d %Y') }}</div>

--- a/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/user/profile_layout.html
+++ b/profiling/test_projects/flaskbb_lite_1/flaskbb/templates/user/profile_layout.html
@@ -16,7 +16,7 @@
                     <div class="col-md-3 col-sm-3 col-xs-12 profile-sidebar">
                         <div class="profile-picture">
                             {% if user.avatar %}
-                            <img src="{{ user.avatar }}" alt="{{ user.username }}'s Avatar">
+                            <img src="{{ user.avatar }}" alt="{{ user.username }}'s Avatar"/>
                             {% endif %}
                         </div>
 

--- a/profiling/test_projects/flaskbb_lite_2/flaskbb/plugins/portal/templates/index.html
+++ b/profiling/test_projects/flaskbb_lite_2/flaskbb/plugins/portal/templates/index.html
@@ -98,7 +98,7 @@
         <div class="portal-content">
             {{ topic.first_post.content | markup | safe }}<br />
         </div>
-        {% if not loop.last %}<hr>{% endif %}
+        {% if not loop.last %}<hr/>{% endif %}
       {% endfor %}
 
       </div> <!-- /.panel-body -->

--- a/profiling/test_projects/flaskbb_lite_2/flaskbb/templates/editor_help.html
+++ b/profiling/test_projects/flaskbb_lite_2/flaskbb/templates/editor_help.html
@@ -16,16 +16,16 @@
                     <h2>Typography</h2>
                     <div class="typography">
                         <span >
-                            # Header1 <br>
-                            ## Header2 <br>
+                            # Header1 <br/>
+                            ## Header2 <br/>
                         </span>
                         <span>
-                            * Unordered item1 <br>
-                            * Unordered item2 <br>
+                            * Unordered item1 <br/>
+                            * Unordered item2 <br/>
                         </span>
                         <span>
-                            1. Ordered item1 <br>
-                            2. Ordered item2 <br>
+                            1. Ordered item1 <br/>
+                            2. Ordered item2 <br/>
                         </span>
                     </div>
                     <p class="text-center" style="margin-top: 1em;">*<em>Emphasized text</em>*</p>
@@ -42,8 +42,8 @@
                     <div class="code-hints" style="margin-top: 2em;">
                         <div class="code-example">
                             <span>
-                            ```python <br>
-                            print "Hello world"<br>
+                            ```python <br/>
+                            print "Hello world"<br/>
                             ```
                             </span>
 


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tag anyhow - that is not an excuse for not writing specification valid code, and I am more than happy to help correct this. In the spirit of an open-source community! The changes in this PullRequest will not break your code in any way.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
